### PR TITLE
Automate games beated README update

### DIFF
--- a/.github/workflows/update-games-analysis.yml
+++ b/.github/workflows/update-games-analysis.yml
@@ -1,0 +1,28 @@
+name: Update games analysis
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install pandas
+      - run: python scripts/update_games_beated_section.py
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet; then
+            git add README.md
+            git commit -m "Update games beated analysis [bot]"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Jupyter Notebook
 http://localhost:8888/?token=meutoken
 
 ## Games Beated Analysis
+<!-- GAMES_BEATED_START -->
 
 ```
 Total games beat: 191
@@ -81,7 +82,7 @@ PlayStation 3      4.33
 Meta Quest 2       3.75
 Nintendo Switch    3.70
 PC                 3.56
-PlayStation 5      3.44
+PlayStation 5      3.47
 PlayStation        3.16
 Mega Drive         3.00
 
@@ -103,7 +104,7 @@ year_I_played
 2017    3.00
 2019    3.00
 2020    3.82
-2021    3.62
+2021    3.67
 2022    3.30
 2023    3.52
 2024    4.20
@@ -113,8 +114,8 @@ Score distribution:
 score
 2      2
 3    114
-4     53
-5     22
+4     52
+5     23
 
 Highest scoring games (score = 5):
                                     title       plataform  year_I_played
@@ -135,9 +136,11 @@ The Walking Dead: A Telltale Games Series              PC           2012
               What Remains of Edith Finch              PC           2020
                             Disco Elysium              PC           2020
                              A Short Hike              PC           2021
+               Uncharted 4: A Thief's End   PlayStation 5           2021
                    The Last of Us Part II   PlayStation 5           2021
                           Half-Life: Alyx    Meta Quest 2           2023
                          Before Your Eyes              PC           2023
 The Legend of Zelda: Tears of the Kingdom Nintendo Switch           2023
                               Alan Wake 2              PC           2024
 ```
+<!-- GAMES_BEATED_END -->

--- a/scripts/update_games_beated_section.py
+++ b/scripts/update_games_beated_section.py
@@ -1,0 +1,33 @@
+import subprocess
+import re
+from pathlib import Path
+
+# Run the analysis script and capture its output
+result = subprocess.run(
+    ["python", "analysis/games/games_beated_analysis.py"],
+    capture_output=True,
+    text=True,
+    check=True,
+)
+analysis_output = result.stdout.strip()
+
+start_marker = "<!-- GAMES_BEATED_START -->"
+end_marker = "<!-- GAMES_BEATED_END -->"
+
+readme_path = Path("README.md")
+readme_text = readme_path.read_text()
+
+new_section = f"{start_marker}\n\n```\n{analysis_output}\n```\n{end_marker}"
+
+# Replace existing section or insert after the heading
+pattern = re.compile(f"{start_marker}.*?{end_marker}", re.S)
+if pattern.search(readme_text):
+    updated_text = pattern.sub(new_section, readme_text)
+else:
+    heading = "## Games Beated Analysis"
+    if heading in readme_text:
+        updated_text = readme_text.replace(heading, heading + "\n" + new_section)
+    else:
+        updated_text = readme_text + "\n" + heading + "\n" + new_section
+
+readme_path.write_text(updated_text)


### PR DESCRIPTION
## Summary
- add GitHub action to run game stats and update README on push to main
- add script to insert the game stats into README
- mark section in README for automated updates

## Testing
- `python scripts/update_games_beated_section.py`


------
https://chatgpt.com/codex/tasks/task_e_684af6576814832199e7e53e97313ade